### PR TITLE
🔧 requirementsのバージョンを固定

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 ruff==0.15.2
-pytest>=8.0
-pytest-asyncio>=0.24
-respx>=0.22
+pytest==9.0.2
+pytest-asyncio==1.3.0
+respx==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-discord.py>=2.6.0
-httpx>=0.28.0
-python-dotenv>=1.0.0
+discord.py==2.6.4
+httpx==0.28.1
+python-dotenv==1.2.1


### PR DESCRIPTION
- requirements.txt / requirements-dev.txt のバージョン指定を >= から == に変更
- 環境差異による意図しない動作を防止