### PR TITLE
✨ Zenn Tech/Idea記事を別チャンネルに分割

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,9 +26,16 @@ intents = discord.Intents.default()
 bot = discord.Client(intents=intents)
 
 
-def _build_controller() -> FeedController:
-    article_service = ZennArticleService()
-    channel_id = int(os.environ["DISCORD_CHANNEL_ID_ZENN"])
+def _build_zenn_tech_controller() -> FeedController:
+    article_service = ZennArticleService("tech")
+    channel_id = int(os.environ["DISCORD_CHANNEL_ID_ZENN_TECH"])
+    feed_service = DiscordFeedService(bot, channel_id)
+    return FeedController(article_service, feed_service)
+
+
+def _build_zenn_idea_controller() -> FeedController:
+    article_service = ZennArticleService("idea")
+    channel_id = int(os.environ["DISCORD_CHANNEL_ID_ZENN_IDEA"])
     feed_service = DiscordFeedService(bot, channel_id)
     return FeedController(article_service, feed_service)
 
@@ -36,8 +43,10 @@ def _build_controller() -> FeedController:
 @tasks.loop(time=SCHEDULE_TIMES)
 async def scheduled_feed_task() -> None:
     logger.info("Scheduled feed task triggered.")
-    controller = _build_controller()
-    await controller.run()
+    zenn_tech_controller = _build_zenn_tech_controller()
+    await zenn_tech_controller.run()
+    zenn_idea_controller = _build_zenn_idea_controller()
+    await zenn_idea_controller.run()
 
 
 @bot.event

--- a/service/zenn_article_service.py
+++ b/service/zenn_article_service.py
@@ -9,6 +9,9 @@ LIKED_COUNT_THRESHOLD = 50
 
 
 class ZennArticleService(IArticleService):
+    def __init__(self, article_type: str) -> None:
+        self._article_type = article_type
+
     async def get_articles(self) -> list[Article]:
         async with httpx.AsyncClient() as client:
             response = await client.get(
@@ -20,7 +23,7 @@ class ZennArticleService(IArticleService):
 
         articles: list[Article] = []
         for item in data.get("articles", []):
-            if item.get("article_type") not in ("tech", "idea"):
+            if item.get("article_type") != self._article_type:
                 continue
             if item.get("liked_count", 0) < LIKED_COUNT_THRESHOLD:
                 continue

--- a/tests/service/test_zenn_article_service.py
+++ b/tests/service/test_zenn_article_service.py
@@ -23,18 +23,16 @@ def _make_item(
 
 
 @respx.mock
-async def test_returns_qualifying_articles():
-    """tech/idea かつ liked_count>=50 の記事のみ返る"""
+async def test_returns_tech_articles():
+    """article_type=tech かつ liked_count>=50 の記事のみ返る"""
     respx.get(ZENN_API_URL).mock(
         return_value=httpx.Response(
             200,
             json={
                 "articles": [
-                    _make_item(title="Tech記事", article_type="tech", liked_count=80),
-                    _make_item(title="Idea記事", article_type="idea", liked_count=60),
-                    _make_item(
-                        title="除外:scraps", article_type="scraps", liked_count=200
-                    ),
+                    _make_item(title="Tech記事A", article_type="tech", liked_count=80),
+                    _make_item(title="Tech記事B", article_type="tech", liked_count=60),
+                    _make_item(title="除外:idea", article_type="idea", liked_count=200),
                     _make_item(
                         title="除外:少ない", article_type="tech", liked_count=10
                     ),
@@ -43,20 +41,46 @@ async def test_returns_qualifying_articles():
         )
     )
 
-    articles = await ZennArticleService().get_articles()
+    articles = await ZennArticleService("tech").get_articles()
 
     assert len(articles) == 2
     assert articles[0] == Article(
-        title="Tech記事", url="https://zenn.dev/user/articles/1"
+        title="Tech記事A", url="https://zenn.dev/user/articles/1"
     )
     assert articles[1] == Article(
-        title="Idea記事", url="https://zenn.dev/user/articles/1"
+        title="Tech記事B", url="https://zenn.dev/user/articles/1"
     )
 
 
 @respx.mock
-async def test_filters_out_wrong_type():
-    """tech/idea 以外の article_type は除外される"""
+async def test_returns_idea_articles():
+    """article_type=idea かつ liked_count>=50 の記事のみ返る"""
+    respx.get(ZENN_API_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "articles": [
+                    _make_item(title="Idea記事A", article_type="idea", liked_count=80),
+                    _make_item(title="除外:tech", article_type="tech", liked_count=200),
+                    _make_item(
+                        title="除外:少ない", article_type="idea", liked_count=10
+                    ),
+                ]
+            },
+        )
+    )
+
+    articles = await ZennArticleService("idea").get_articles()
+
+    assert len(articles) == 1
+    assert articles[0] == Article(
+        title="Idea記事A", url="https://zenn.dev/user/articles/1"
+    )
+
+
+@respx.mock
+async def test_filters_out_other_types():
+    """指定した article_type 以外は除外される"""
     respx.get(ZENN_API_URL).mock(
         return_value=httpx.Response(
             200,
@@ -69,7 +93,7 @@ async def test_filters_out_wrong_type():
         )
     )
 
-    articles = await ZennArticleService().get_articles()
+    articles = await ZennArticleService("tech").get_articles()
 
     assert articles == []
 
@@ -89,7 +113,7 @@ async def test_filters_out_low_liked_count():
         )
     )
 
-    articles = await ZennArticleService().get_articles()
+    articles = await ZennArticleService("tech").get_articles()
 
     assert len(articles) == 1
     assert articles[0].title == "境界ちょうど"
@@ -102,7 +126,7 @@ async def test_empty_response():
         return_value=httpx.Response(200, json={"articles": []})
     )
 
-    articles = await ZennArticleService().get_articles()
+    articles = await ZennArticleService("tech").get_articles()
 
     assert articles == []
 
@@ -115,4 +139,4 @@ async def test_http_error_raises():
     import pytest
 
     with pytest.raises(httpx.HTTPStatusError):
-        await ZennArticleService().get_articles()
+        await ZennArticleService("tech").get_articles()


### PR DESCRIPTION
## 概要

Zennから取得した記事をarticle_typeに応じて別々のDiscordチャンネルに投稿するよう分割した。

closes #6

## 変更点

- `ZennArticleService` をパラメータ化し、コンストラクタで `article_type` を受け取るよう変更
- `main.py` でtech用・idea用のControllerを2つ作成し、スケジュールタスク内で順に実行
- 環境変数を `DISCORD_CHANNEL_ID_ZENN` → `DISCORD_CHANNEL_ID_ZENN_TECH` / `DISCORD_CHANNEL_ID_ZENN_IDEA` に変更
- テストをパラメータ化に合わせて更新（tech用・idea用に分割）

## 備考

- `FeedController` / `DiscordFeedService` / インターフェース / `Article` モデルは変更なし
- `.env` の `DISCORD_CHANNEL_ID_ZENN_TECH` と `DISCORD_CHANNEL_ID_ZENN_IDEA` に実際のチャンネルIDを設定する必要あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)