### PR TITLE
記事の全文取得・AI要約・Discord通知を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind",
     "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind"
   ],
-  "postCreateCommand": "pip install -r requirements.txt -r requirements-dev.txt",
+  "postCreateCommand": "pip install -r requirements.txt -r requirements-dev.txt && playwright install chromium && playwright install-deps chromium",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/controller/feed_controller.py
+++ b/controller/feed_controller.py
@@ -2,6 +2,8 @@ import logging
 
 from interface.i_article_service import IArticleService
 from interface.i_feed_service import IFeedService
+from interface.i_scraping_service import IScrapingService
+from interface.i_summary_service import ISummaryService
 from service.article_dedup_service import ArticleDedupService
 
 logger = logging.getLogger(__name__)
@@ -13,10 +15,14 @@ class FeedController:
         article_service: IArticleService,
         feed_service: IFeedService,
         article_dedup_service: ArticleDedupService,
+        scraping_service: IScrapingService,
+        summary_service: ISummaryService,
     ) -> None:
         self._article_service = article_service
         self._feed_service = feed_service
         self._article_dedup_service = article_dedup_service
+        self._scraping_service = scraping_service
+        self._summary_service = summary_service
 
     async def run(self) -> None:
         logger.info("Starting feed task...")
@@ -27,6 +33,16 @@ class FeedController:
         if not new_articles:
             logger.info("No new articles. Skipping post.")
             return
+
+        for article in new_articles:
+            try:
+                body = await self._scraping_service.fetch_body(article.url)
+                article.summary_result = await self._summary_service.summarize(
+                    article.title, body
+                )
+            except Exception:
+                logger.exception("Failed to summarize article: %s", article.url)
+
         await self._feed_service.post_articles(new_articles)
         await self._article_dedup_service.mark_as_posted(new_articles)
         logger.info("Feed posted.")

--- a/interface/i_scraping_service.py
+++ b/interface/i_scraping_service.py
@@ -1,0 +1,6 @@
+from abc import ABC, abstractmethod
+
+
+class IScrapingService(ABC):
+    @abstractmethod
+    async def fetch_body(self, url: str) -> str: ...

--- a/interface/i_summary_service.py
+++ b/interface/i_summary_service.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+
+from model.summary_result import SummaryResult
+
+
+class ISummaryService(ABC):
+    @abstractmethod
+    async def summarize(self, title: str, body: str) -> SummaryResult: ...

--- a/main.py
+++ b/main.py
@@ -11,8 +11,10 @@ from repository.dynamodb_posted_article_repository import (
     DynamodbPostedArticleRepository,
 )
 from service.article_dedup_service import ArticleDedupService
+from service.bedrock_summary_service import BedrockSummaryService
 from service.discord_feed_service import DiscordFeedService
 from service.zenn_article_service import ZennArticleService
+from service.zenn_scraping_service import ZennScrapingService
 
 logging.basicConfig(
     level=logging.INFO,
@@ -36,7 +38,11 @@ def _build_zenn_tech_controller() -> FeedController:
     feed_service = DiscordFeedService(bot, channel_id)
     repo = DynamodbPostedArticleRepository("zenn_tech")
     dedup_service = ArticleDedupService(repo)
-    return FeedController(article_service, feed_service, dedup_service)
+    scraping_service = ZennScrapingService()
+    summary_service = BedrockSummaryService()
+    return FeedController(
+        article_service, feed_service, dedup_service, scraping_service, summary_service
+    )
 
 
 def _build_zenn_idea_controller() -> FeedController:
@@ -45,7 +51,11 @@ def _build_zenn_idea_controller() -> FeedController:
     feed_service = DiscordFeedService(bot, channel_id)
     repo = DynamodbPostedArticleRepository("zenn_idea")
     dedup_service = ArticleDedupService(repo)
-    return FeedController(article_service, feed_service, dedup_service)
+    scraping_service = ZennScrapingService()
+    summary_service = BedrockSummaryService()
+    return FeedController(
+        article_service, feed_service, dedup_service, scraping_service, summary_service
+    )
 
 
 @tasks.loop(time=SCHEDULE_TIMES)

--- a/model/article.py
+++ b/model/article.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
 
+from model.summary_result import SummaryResult
 
-@dataclass(frozen=True)
+
+@dataclass
 class Article:
     title: str
     url: str
+    summary_result: SummaryResult | None = None

--- a/model/summary_result.py
+++ b/model/summary_result.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    summary: list[str]
+    glossary: list[dict[str, str]] | None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3==1.42.55
 discord.py==2.6.4
 httpx==0.28.1
+playwright==1.58.0
 python-dotenv==1.2.1

--- a/service/bedrock_summary_service.py
+++ b/service/bedrock_summary_service.py
@@ -1,0 +1,79 @@
+import logging
+import os
+
+import boto3
+
+from interface.i_summary_service import ISummaryService
+from model.summary_result import SummaryResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_ID = "global.anthropic.claude-sonnet-4-6"
+
+_SYSTEM_PROMPT = """\
+あなたは技術記事を要約するアシスタントです。
+与えられた記事を読み、output_summaryツールを使って結果を返してください。"""
+
+_TOOL_DEF = {
+    "toolSpec": {
+        "name": "output_summary",
+        "description": "記事の要約と用語解説を出力する",
+        "inputSchema": {
+            "json": {
+                "type": "object",
+                "properties": {
+                    "summary": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "記事の要点を最大5つ。各項目は50文字以内の短い1文にすること。",
+                    },
+                    "glossary": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "term": {"type": "string"},
+                                "explanation": {"type": "string"},
+                            },
+                            "required": ["term", "explanation"],
+                        },
+                        "description": "専門用語の解説。専門用語がない場合は省略。",
+                    },
+                },
+                "required": ["summary"],
+            }
+        },
+    }
+}
+
+
+class BedrockSummaryService(ISummaryService):
+    def __init__(self, client=None) -> None:
+        self._client = client or boto3.client(
+            "bedrock-runtime", region_name="ap-northeast-1"
+        )
+        self._model_id = os.environ.get("BEDROCK_MODEL_ID", DEFAULT_MODEL_ID)
+
+    async def summarize(self, title: str, body: str) -> SummaryResult:
+        user_message = f"# {title}\n\n{body}"
+        response = self._client.converse(
+            modelId=self._model_id,
+            system=[{"text": _SYSTEM_PROMPT}],
+            messages=[{"role": "user", "content": [{"text": user_message}]}],
+            toolConfig={
+                "tools": [_TOOL_DEF],
+                "toolChoice": {"tool": {"name": "output_summary"}},
+            },
+        )
+        tool_input = self._extract_tool_input(response)
+        return SummaryResult(
+            summary=tool_input["summary"],
+            glossary=tool_input.get("glossary"),
+        )
+
+    def _extract_tool_input(self, response: dict) -> dict:
+        content = response["output"]["message"]["content"]
+        for block in content:
+            if block.get("toolUse", {}).get("name") == "output_summary":
+                return block["toolUse"]["input"]
+        raise ValueError("output_summary tool use block not found in response")

--- a/service/discord_feed_service.py
+++ b/service/discord_feed_service.py
@@ -4,6 +4,24 @@ from interface.i_feed_service import IFeedService
 from model.article import Article
 
 THREAD_NAME_MAX_LENGTH = 100
+CONTENT_MAX_LENGTH = 2000
+
+
+def _build_content(article: Article) -> str:
+    parts = [article.url]
+
+    if article.summary_result:
+        parts.append("\n**要約**")
+        for item in article.summary_result.summary:
+            parts.append(f"- {item}")
+
+        if article.summary_result.glossary:
+            parts.append("\n**用語解説**")
+            for entry in article.summary_result.glossary:
+                parts.append(f"- **{entry['term']}**: {entry['explanation']}")
+
+    content = "\n".join(parts)
+    return content[:CONTENT_MAX_LENGTH]
 
 
 class DiscordFeedService(IFeedService):
@@ -19,5 +37,5 @@ class DiscordFeedService(IFeedService):
         for article in articles:
             await channel.create_thread(
                 name=article.title[:THREAD_NAME_MAX_LENGTH],
-                content=article.url,
+                content=_build_content(article),
             )

--- a/service/zenn_scraping_service.py
+++ b/service/zenn_scraping_service.py
@@ -1,0 +1,22 @@
+from playwright.async_api import async_playwright
+
+from interface.i_scraping_service import IScrapingService
+
+BODY_MAX_LENGTH = 100_000
+ZENN_ARTICLE_SELECTOR = ".znc"
+
+
+class ZennScrapingService(IScrapingService):
+    async def fetch_body(self, url: str) -> str:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch()
+            try:
+                page = await browser.new_page()
+                await page.goto(url)
+                element = await page.query_selector(ZENN_ARTICLE_SELECTOR)
+                if element is None:
+                    return ""
+                text = await element.inner_text()
+                return text[:BODY_MAX_LENGTH]
+            finally:
+                await browser.close()

--- a/tests/controller/test_feed_controller.py
+++ b/tests/controller/test_feed_controller.py
@@ -4,6 +4,7 @@ import pytest
 
 from controller.feed_controller import FeedController
 from model.article import Article
+from model.summary_result import SummaryResult
 
 
 @pytest.fixture
@@ -33,12 +34,53 @@ def mock_dedup_service(articles):
     return mock
 
 
+@pytest.fixture
+def mock_scraping_service():
+    mock = AsyncMock()
+    mock.fetch_body.return_value = "本文テキスト"
+    return mock
+
+
+@pytest.fixture
+def mock_summary_service():
+    mock = AsyncMock()
+    mock.summarize.return_value = SummaryResult(
+        summary=["ポイント1", "ポイント2"], glossary=None
+    )
+    return mock
+
+
+def _make_controller(
+    article_service,
+    feed_service,
+    dedup_service,
+    scraping_service,
+    summary_service,
+) -> FeedController:
+    return FeedController(
+        article_service,
+        feed_service,
+        dedup_service,
+        scraping_service,
+        summary_service,
+    )
+
+
 async def test_run_passes_articles_to_feed_service(
-    mock_article_service, mock_feed_service, mock_dedup_service, articles
+    mock_article_service,
+    mock_feed_service,
+    mock_dedup_service,
+    mock_scraping_service,
+    mock_summary_service,
+    articles,
 ):
     """get_articles の戻り値が dedup を経て post_articles に渡される"""
-    controller = FeedController(
-        mock_article_service, mock_feed_service, mock_dedup_service
+    controller = _make_controller(
+        mock_article_service,
+        mock_feed_service,
+        mock_dedup_service,
+        mock_scraping_service,
+        mock_summary_service,
     )
     await controller.run()
 
@@ -48,14 +90,21 @@ async def test_run_passes_articles_to_feed_service(
 
 
 async def test_run_propagates_article_service_error(
-    mock_feed_service, mock_dedup_service
+    mock_feed_service,
+    mock_dedup_service,
+    mock_scraping_service,
+    mock_summary_service,
 ):
     """get_articles 例外時、post_articles は呼ばれず例外が伝播する"""
     mock_article_service = AsyncMock()
     mock_article_service.get_articles.side_effect = RuntimeError("API error")
 
-    controller = FeedController(
-        mock_article_service, mock_feed_service, mock_dedup_service
+    controller = _make_controller(
+        mock_article_service,
+        mock_feed_service,
+        mock_dedup_service,
+        mock_scraping_service,
+        mock_summary_service,
     )
 
     with pytest.raises(RuntimeError, match="API error"):
@@ -65,15 +114,23 @@ async def test_run_propagates_article_service_error(
 
 
 async def test_run_posts_only_dedup_articles(
-    mock_article_service, mock_feed_service, articles
+    mock_article_service,
+    mock_feed_service,
+    mock_scraping_service,
+    mock_summary_service,
+    articles,
 ):
     """dedup後の記事のみpostされる"""
     new_articles = [articles[0]]
     mock_dedup_service = AsyncMock()
     mock_dedup_service.filter_unposted.return_value = new_articles
 
-    controller = FeedController(
-        mock_article_service, mock_feed_service, mock_dedup_service
+    controller = _make_controller(
+        mock_article_service,
+        mock_feed_service,
+        mock_dedup_service,
+        mock_scraping_service,
+        mock_summary_service,
     )
     await controller.run()
 
@@ -81,14 +138,21 @@ async def test_run_posts_only_dedup_articles(
 
 
 async def test_run_skips_post_when_no_new_articles(
-    mock_article_service, mock_feed_service
+    mock_article_service,
+    mock_feed_service,
+    mock_scraping_service,
+    mock_summary_service,
 ):
     """新規記事なし→post未実行"""
     mock_dedup_service = AsyncMock()
     mock_dedup_service.filter_unposted.return_value = []
 
-    controller = FeedController(
-        mock_article_service, mock_feed_service, mock_dedup_service
+    controller = _make_controller(
+        mock_article_service,
+        mock_feed_service,
+        mock_dedup_service,
+        mock_scraping_service,
+        mock_summary_service,
     )
     await controller.run()
 
@@ -96,11 +160,20 @@ async def test_run_skips_post_when_no_new_articles(
 
 
 async def test_run_marks_as_posted_after_post(
-    mock_article_service, mock_feed_service, mock_dedup_service, articles
+    mock_article_service,
+    mock_feed_service,
+    mock_dedup_service,
+    mock_scraping_service,
+    mock_summary_service,
+    articles,
 ):
     """post後にmark_as_postedが呼ばれる"""
-    controller = FeedController(
-        mock_article_service, mock_feed_service, mock_dedup_service
+    controller = _make_controller(
+        mock_article_service,
+        mock_feed_service,
+        mock_dedup_service,
+        mock_scraping_service,
+        mock_summary_service,
     )
     await controller.run()
 
@@ -109,17 +182,101 @@ async def test_run_marks_as_posted_after_post(
 
 
 async def test_run_does_not_mark_posted_on_post_failure(
-    mock_article_service, mock_dedup_service, articles
+    mock_article_service,
+    mock_dedup_service,
+    mock_scraping_service,
+    mock_summary_service,
+    articles,
 ):
     """post失敗→mark_as_posted未実行"""
     mock_feed_service = AsyncMock()
     mock_feed_service.post_articles.side_effect = RuntimeError("Discord error")
 
-    controller = FeedController(
-        mock_article_service, mock_feed_service, mock_dedup_service
+    controller = _make_controller(
+        mock_article_service,
+        mock_feed_service,
+        mock_dedup_service,
+        mock_scraping_service,
+        mock_summary_service,
     )
 
     with pytest.raises(RuntimeError, match="Discord error"):
         await controller.run()
 
     mock_dedup_service.mark_as_posted.assert_not_awaited()
+
+
+async def test_run_sets_summary_on_article(
+    mock_article_service,
+    mock_feed_service,
+    mock_dedup_service,
+    mock_scraping_service,
+    mock_summary_service,
+    articles,
+):
+    """要約成功時、article.summary_result に SummaryResult が代入される"""
+    expected = SummaryResult(
+        summary=["要点A", "要点B"],
+        glossary=[{"term": "用語", "explanation": "説明"}],
+    )
+    mock_summary_service.summarize.return_value = expected
+    controller = _make_controller(
+        mock_article_service,
+        mock_feed_service,
+        mock_dedup_service,
+        mock_scraping_service,
+        mock_summary_service,
+    )
+    await controller.run()
+
+    for article in articles:
+        assert article.summary_result == expected
+
+
+async def test_run_continues_on_summary_failure(
+    mock_article_service,
+    mock_feed_service,
+    mock_dedup_service,
+    mock_scraping_service,
+    articles,
+):
+    """個別記事の要約失敗→その記事は summary_result=None のまま投稿を継続する"""
+    mock_summary_service = AsyncMock()
+    mock_summary_service.summarize.side_effect = RuntimeError("Bedrock error")
+
+    controller = _make_controller(
+        mock_article_service,
+        mock_feed_service,
+        mock_dedup_service,
+        mock_scraping_service,
+        mock_summary_service,
+    )
+    await controller.run()
+
+    # 例外を再送出せず post_articles が呼ばれる
+    mock_feed_service.post_articles.assert_awaited_once_with(articles)
+    for article in articles:
+        assert article.summary_result is None
+
+
+async def test_run_skips_summary_when_no_new_articles(
+    mock_article_service,
+    mock_feed_service,
+    mock_scraping_service,
+    mock_summary_service,
+):
+    """新規記事なし→スクレイピング・要約は実行されない"""
+    mock_dedup_service = AsyncMock()
+    mock_dedup_service.filter_unposted.return_value = []
+
+    controller = _make_controller(
+        mock_article_service,
+        mock_feed_service,
+        mock_dedup_service,
+        mock_scraping_service,
+        mock_summary_service,
+    )
+    await controller.run()
+
+    mock_scraping_service.fetch_body.assert_not_awaited()
+    mock_summary_service.summarize.assert_not_awaited()

--- a/tests/service/test_bedrock_summary_service.py
+++ b/tests/service/test_bedrock_summary_service.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from service.bedrock_summary_service import BedrockSummaryService
+from model.summary_result import SummaryResult
+
+
+def _make_converse_response(summary: list[str], glossary: list[dict] | None = None):
+    tool_input = {"summary": summary}
+    if glossary is not None:
+        tool_input["glossary"] = glossary
+    return {
+        "output": {
+            "message": {
+                "content": [
+                    {
+                        "toolUse": {
+                            "name": "output_summary",
+                            "input": tool_input,
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+
+def _make_service(response: dict) -> BedrockSummaryService:
+    mock_client = MagicMock()
+    mock_client.converse.return_value = response
+    return BedrockSummaryService(client=mock_client)
+
+
+async def test_summarize_returns_summary_and_glossary():
+    """summary と glossary が正しく SummaryResult にマッピングされる"""
+    summary = ["ポイント1", "ポイント2"]
+    glossary = [{"term": "API", "explanation": "Application Programming Interface"}]
+    service = _make_service(_make_converse_response(summary, glossary))
+
+    result = await service.summarize("テスト記事", "本文テキスト")
+
+    assert isinstance(result, SummaryResult)
+    assert result.summary == summary
+    assert result.glossary == glossary
+
+
+async def test_summarize_returns_none_glossary_when_absent():
+    """glossary が省略された場合は None になる"""
+    service = _make_service(_make_converse_response(["ポイント1"]))
+
+    result = await service.summarize("テスト記事", "本文テキスト")
+
+    assert result.glossary is None
+
+
+async def test_summarize_sends_correct_request():
+    """converse に正しいモデルIDとメッセージが渡される"""
+    mock_client = MagicMock()
+    mock_client.converse.return_value = _make_converse_response(["要点"])
+    service = BedrockSummaryService(client=mock_client)
+
+    await service.summarize("記事タイトル", "記事本文")
+
+    call_kwargs = mock_client.converse.call_args.kwargs
+    assert "記事タイトル" in call_kwargs["messages"][0]["content"][0]["text"]
+    assert "記事本文" in call_kwargs["messages"][0]["content"][0]["text"]
+    tool_names = [t["toolSpec"]["name"] for t in call_kwargs["toolConfig"]["tools"]]
+    assert "output_summary" in tool_names
+
+
+async def test_summarize_raises_when_tool_use_not_found():
+    """レスポンスに output_summary ブロックがない場合は ValueError"""
+    mock_client = MagicMock()
+    mock_client.converse.return_value = {
+        "output": {"message": {"content": [{"text": "unexpected"}]}}
+    }
+    service = BedrockSummaryService(client=mock_client)
+
+    with pytest.raises(ValueError, match="output_summary"):
+        await service.summarize("タイトル", "本文")

--- a/tests/service/test_discord_feed_service.py
+++ b/tests/service/test_discord_feed_service.py
@@ -3,7 +3,8 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 
 from model.article import Article
-from service.discord_feed_service import DiscordFeedService
+from model.summary_result import SummaryResult
+from service.discord_feed_service import CONTENT_MAX_LENGTH, DiscordFeedService
 
 
 _UNSET = object()
@@ -67,3 +68,71 @@ async def test_falls_back_to_fetch_channel():
     bot.get_channel.assert_called_once_with(123)
     bot.fetch_channel.assert_awaited_once_with(123)
     channel.create_thread.assert_awaited_once()
+
+
+async def test_content_includes_summary():
+    """summary_result がある場合、content に箇条書きが含まれる"""
+    service, _, channel = _make_service()
+    article = Article(
+        title="記事A",
+        url="https://zenn.dev/a",
+        summary_result=SummaryResult(summary=["ポイント1", "ポイント2"], glossary=None),
+    )
+
+    await service.post_articles([article])
+
+    call_kwargs = channel.create_thread.call_args.kwargs
+    content = call_kwargs["content"]
+    assert "https://zenn.dev/a" in content
+    assert "- ポイント1" in content
+    assert "- ポイント2" in content
+    assert "**要約**" in content
+
+
+async def test_content_includes_glossary():
+    """glossary がある場合、content に用語解説が含まれる"""
+    service, _, channel = _make_service()
+    article = Article(
+        title="記事A",
+        url="https://zenn.dev/a",
+        summary_result=SummaryResult(
+            summary=["ポイント1"],
+            glossary=[
+                {"term": "API", "explanation": "Application Programming Interface"}
+            ],
+        ),
+    )
+
+    await service.post_articles([article])
+
+    call_kwargs = channel.create_thread.call_args.kwargs
+    content = call_kwargs["content"]
+    assert "**用語解説**" in content
+    assert "**API**" in content
+    assert "Application Programming Interface" in content
+
+
+async def test_content_truncated_to_max_length():
+    """content が上限を超える場合は 2000 文字に切り詰める"""
+    service, _, channel = _make_service()
+    article = Article(
+        title="記事",
+        url="https://zenn.dev/a",
+        summary_result=SummaryResult(summary=["x" * 500] * 5, glossary=None),
+    )
+
+    await service.post_articles([article])
+
+    call_kwargs = channel.create_thread.call_args.kwargs
+    assert len(call_kwargs["content"]) <= CONTENT_MAX_LENGTH
+
+
+async def test_content_without_summary_is_just_url():
+    """summary_result がない場合、content は URL のみ"""
+    service, _, channel = _make_service()
+    article = Article(title="記事", url="https://zenn.dev/a")
+
+    await service.post_articles([article])
+
+    call_kwargs = channel.create_thread.call_args.kwargs
+    assert call_kwargs["content"] == "https://zenn.dev/a"

--- a/tests/service/test_zenn_scraping_service.py
+++ b/tests/service/test_zenn_scraping_service.py
@@ -1,0 +1,88 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from service.zenn_scraping_service import BODY_MAX_LENGTH, ZennScrapingService
+
+
+def _make_playwright_ctx(inner_text: str = "article body", element_found: bool = True):
+    mock_element = AsyncMock()
+    mock_element.inner_text = AsyncMock(return_value=inner_text)
+
+    mock_page = AsyncMock()
+    mock_page.goto = AsyncMock()
+    mock_page.query_selector = AsyncMock(
+        return_value=mock_element if element_found else None
+    )
+
+    mock_browser = AsyncMock()
+    mock_browser.new_page = AsyncMock(return_value=mock_page)
+    mock_browser.close = AsyncMock()
+
+    mock_p = MagicMock()
+    mock_p.chromium.launch = AsyncMock(return_value=mock_browser)
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_p)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_ctx, mock_page, mock_browser
+
+
+async def test_fetch_body_returns_article_text():
+    """セレクタにマッチした要素のテキストを返す"""
+    mock_ctx, mock_page, _ = _make_playwright_ctx("article text")
+
+    with patch("service.zenn_scraping_service.async_playwright", return_value=mock_ctx):
+        service = ZennScrapingService()
+        result = await service.fetch_body("https://zenn.dev/test/articles/abc")
+
+    assert result == "article text"
+    mock_page.goto.assert_awaited_once_with("https://zenn.dev/test/articles/abc")
+
+
+async def test_fetch_body_returns_empty_when_element_not_found():
+    """セレクタにマッチする要素がない場合は空文字を返す"""
+    mock_ctx, _, _ = _make_playwright_ctx(element_found=False)
+
+    with patch("service.zenn_scraping_service.async_playwright", return_value=mock_ctx):
+        service = ZennScrapingService()
+        result = await service.fetch_body("https://zenn.dev/test/articles/abc")
+
+    assert result == ""
+
+
+async def test_fetch_body_truncates_long_text():
+    """本文が上限を超える場合は BODY_MAX_LENGTH 文字に切り詰める"""
+    long_text = "x" * (BODY_MAX_LENGTH + 1000)
+    mock_ctx, _, _ = _make_playwright_ctx(inner_text=long_text)
+
+    with patch("service.zenn_scraping_service.async_playwright", return_value=mock_ctx):
+        service = ZennScrapingService()
+        result = await service.fetch_body("https://zenn.dev/test/articles/abc")
+
+    assert len(result) == BODY_MAX_LENGTH
+
+
+async def test_fetch_body_closes_browser_on_error():
+    """ページ取得中に例外が発生しても browser.close が呼ばれる"""
+    mock_page = AsyncMock()
+    mock_page.goto = AsyncMock(side_effect=RuntimeError("network error"))
+
+    mock_browser = AsyncMock()
+    mock_browser.new_page = AsyncMock(return_value=mock_page)
+    mock_browser.close = AsyncMock()
+
+    mock_p = MagicMock()
+    mock_p.chromium.launch = AsyncMock(return_value=mock_browser)
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_p)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("service.zenn_scraping_service.async_playwright", return_value=mock_ctx):
+        import pytest
+
+        service = ZennScrapingService()
+        with pytest.raises(RuntimeError, match="network error"):
+            await service.fetch_body("https://zenn.dev/test/articles/abc")
+
+    mock_browser.close.assert_awaited_once()


### PR DESCRIPTION
## 概要

closes #11

記事の全文スクレイピング → AWS Bedrock（Claude Sonnet 4.6）による要約生成 → Discord通知の一連のフローを実装した。

## 変更点

- `ZennScrapingService` を追加（Playwrightで記事本文を取得）
- `BedrockSummaryService` を追加（Bedrockのtool useで要約・用語解説を構造化出力）
- `SummaryResult` モデルを追加（`summary: list[str]`、`glossary: list[dict] | None`）
- `Article` モデルに `summary_result` フィールドを追加（mutableに変更）
- `FeedController` で各記事に要約を付与するロジックを追加（失敗時はログのみ・投稿継続）
- `DiscordFeedService` の投稿内容に要約・用語解説を整形して追加（2000文字上限）
- `IScrapingService` / `ISummaryService` インターフェースを追加
- devcontainerに `playwright install chromium` を追加
- 各レイヤーのテストを追加・更新

## 備考

- 要約失敗時（スクレイピングエラー・Bedrockエラー）はその記事を `summary_result=None` のまま投稿を続ける（フォールトトレラント）
- Bedrock model IDは環境変数 `BEDROCK_MODEL_ID` で上書き可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)